### PR TITLE
fix: smtp starttls compatibility issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/gorilla/websocket v1.5.0
 	github.com/lukasjarosch/go-docx v0.4.7
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pkoukk/tiktoken-go v0.1.6
 	github.com/russross/blackfriday/v2 v2.1.0
@@ -22,7 +23,7 @@ require (
 	github.com/spf13/viper v1.16.0
 	github.com/volcengine/volc-sdk-golang v1.0.127
 	golang.org/x/net v0.15.0
-	gopkg.in/mail.v2 v2.3.1
+	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 )
 
 require (
@@ -53,7 +54,6 @@ require (
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
-	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1018,10 +1018,10 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
+gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df h1:n7WqCuqOuCbNr617RXOY0AWRXxgwEyPp2z+p0+hgMuE=
+gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df/go.mod h1:LRQQ+SO6ZHR7tOkpBDuZnXENFzX8qRjMDMyPD6BRkCw=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/mail.v2 v2.3.1 h1:WYFn/oANrAGP2C0dcV6/pbkPzv8yGzqTjPmTeO7qoXk=
-gopkg.in/mail.v2 v2.3.1/go.mod h1:htwXN1Qh09vZJ1NVKxQqHPBaCBbzKhp5GzuJEA4VJWw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=

--- a/utils/smtp.go
+++ b/utils/smtp.go
@@ -38,16 +38,16 @@ func (s *SmtpPoster) SendMail(to string, subject string, body string) error {
 		return fmt.Errorf("smtp not configured properly")
 	}
 
-	// 创建 gomail 消息对象
+	// Create gomail message object
 	message := gomail.NewMessage()
 
-	// 根据用户名是否包含"@"来决定发件人地址
+	// Determine sender address based on whether the username contains "@"
 	var from string
 	if strings.Contains(s.Username, "@") {
-		// 如果用户名包含"@", 则直接使用 From 作为发件人
+		// If the username contains "@", use From as the sender
 		from = s.From
 	} else {
-		// 否则，将用户名和 From 组合成发件人的邮箱地址
+		// Otherwise, combine the username and From to form the sender's email address
 		from = fmt.Sprintf("%s <%s>", s.Username, s.From)
 	}
 	message.SetHeader("From", from)
@@ -55,21 +55,20 @@ func (s *SmtpPoster) SendMail(to string, subject string, body string) error {
 	message.SetHeader("Subject", subject)
 	message.SetBody("text/html", body)
 
-	// 创建 gomail 拨号器
 	dialer := gomail.NewDialer(s.Host, s.Port, s.Username, s.Password)
 
-	// 如果启用TLS协议
+	// If TLS protocol is enabled
 	if s.Protocol {
 		dialer.TLSConfig = &tls.Config{
-			InsecureSkipVerify: false,  // 禁用不安全的证书验证
-			ServerName:         s.Host, // 设置ServerName为SMTP主机
+			InsecureSkipVerify: false,  // Disable insecure certificate verification
+			ServerName:         s.Host, // Set ServerName to the SMTP host
 		}
 	} else {
-		// 启用SSL时，不需要STARTTLS，直接进行加密连接
+		// When SSL is enabled, no need for STARTTLS, directly establish an encrypted connection
 		dialer.SSL = true
 	}
 
-	// 针对Outlook的STARTTLS策略适配器
+	//  outlook starttls policy
 	if strings.Contains(s.Host, "outlook") {
 		dialer.TLSConfig = &tls.Config{
 			InsecureSkipVerify: false,
@@ -77,7 +76,6 @@ func (s *SmtpPoster) SendMail(to string, subject string, body string) error {
 		}
 	}
 
-	// 拨号并发送邮件
 	if err := dialer.DialAndSend(message); err != nil {
 		return fmt.Errorf("sent mail failed: %s", err.Error())
 	}


### PR DESCRIPTION
原先mail.v2实现的StartTLS存在问题，导致其与一部分SMTP服务商无法成功握手，此提交将smtp.go的实现转换为gomail.v2以解决StartTLS相关问题，我已分别测试过一家使用StartTLS的服务商(ahasend)和一家使用SSL的服务商(阿里云)。