### PR TITLE
fix: Overflow-hidden属性使思考块超出部分文字无法正常显示

### DIFF
--- a/app/src/components/ThinkContent.tsx
+++ b/app/src/components/ThinkContent.tsx
@@ -41,7 +41,7 @@ export function ThinkContent({ content, isComplete = true }: ThinkContentProps) 
       
       <div
         className={cn(
-          "overflow-hidden transition-all duration-200",
+          "overflow-auto transition-all duration-200",
           isExpanded ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0"
         )}
       >


### PR DESCRIPTION
很小的一个改动，Overflow-hidden属性使思考块超出部分文字无法正常显示，所以改成了overflow-auto

![image](https://github.com/user-attachments/assets/5fd8781d-795f-492d-b43a-33c88e4cd036)
